### PR TITLE
split into chunks based on top-level pages

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,12 +1,8 @@
-import React from "react";
+import React, { Suspense, lazy } from "react";
 import "./App.scss";
 import { Navigation } from "./components/Navigation";
 import { Footer } from "./components/Footer";
 import { version } from "../package.json";
-import { Build } from "./pages/Build";
-import { Play } from "./pages/Play";
-import { About } from "./pages/About";
-import { Start } from "./pages/Start";
 import {
   BrowserRouter as Router,
   Switch,
@@ -17,35 +13,42 @@ import {
 import { defaultTeamsSpec } from "./model/problem";
 import { GraphQLProvider } from "./model/contexts";
 
+const Build = lazy(() => import("./pages/Build"));
+const Play = lazy(() => import("./pages/Play"));
+const About = lazy(() => import("./pages/About"));
+const Start = lazy(() => import("./pages/Start"));
+
 function App() {
   return (
     <div className="App">
       <GraphQLProvider>
         <Router>
           <Navigation version={version} />
-          <Switch>
-            <Route path="/about">
-              <About />
-            </Route>
-            <Route path="/play/:gridSpec/:teamsSpec">
-              <Play />
-            </Route>
-            <Route path="/play/:gridSpec">
-              <FallbackWhenTeamSpecMissing />
-            </Route>
-            <Route path="/play">
-              <Redirect to="/" />;
-            </Route>
-            <Route path="/build/:areaSpec">
-              <Build />
-            </Route>
-            <Route path="/build/">
-              <FallbackWhenAreaSpecMissing />
-            </Route>
-            <Route path="/">
-              <Start />
-            </Route>
-          </Switch>
+          <Suspense fallback={<div></div>}>
+            <Switch>
+              <Route path="/about">
+                <About />
+              </Route>
+              <Route path="/play/:gridSpec/:teamsSpec">
+                <Play />
+              </Route>
+              <Route path="/play/:gridSpec">
+                <FallbackWhenTeamSpecMissing />
+              </Route>
+              <Route path="/play">
+                <Redirect to="/" />;
+              </Route>
+              <Route path="/build/:areaSpec">
+                <Build />
+              </Route>
+              <Route path="/build/">
+                <FallbackWhenAreaSpecMissing />
+              </Route>
+              <Route path="/">
+                <Start />
+              </Route>
+            </Switch>
+          </Suspense>
           <Footer />
         </Router>
       </GraphQLProvider>

--- a/src/pages/About.js
+++ b/src/pages/About.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Rules } from "../components/Rules";
 
-export function About() {
+export default function About() {
   return (
     <>
       <section className="section">

--- a/src/pages/Build.js
+++ b/src/pages/Build.js
@@ -91,7 +91,7 @@ const Instance = observer(() => {
   );
 });
 
-export function Build() {
+export default function Build() {
   const { areaSpec } = useParams();
   try {
     const gridSpec = parseAreaSpec(areaSpec).toGridSpec();

--- a/src/pages/Play.js
+++ b/src/pages/Play.js
@@ -59,7 +59,7 @@ function gameInstance(problem) {
   );
 }
 
-export function Play() {
+export default function Play() {
   const { gridSpec, teamsSpec } = useParams();
 
   try {

--- a/src/pages/Start.js
+++ b/src/pages/Start.js
@@ -74,7 +74,7 @@ function Build() {
   );
 }
 
-export function Start() {
+export default function Start() {
   return (
     <section className="hero is-medium is-primary is-bold">
       <div className="hero-body">


### PR DESCRIPTION
- lazy load each of Build, Play, About, Start
  - tested locally in Lighthouse, reduces
  time-to-first-paint from 3s to 2.6s